### PR TITLE
Added Colors to NameColorCommand messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'xyz.gupton.nickolas.beepsky'
-version '2.0.1'
+version '2.0.2'
 
 apply plugin: 'java'
 apply plugin: 'application'

--- a/src/main/java/xyz/gupton/nickolas/beepsky/fun/commands/NameColorCommand.java
+++ b/src/main/java/xyz/gupton/nickolas/beepsky/fun/commands/NameColorCommand.java
@@ -54,7 +54,7 @@ public class NameColorCommand implements Command {
 
       // if the name color specified is a valid hex code
       if (!Pattern.compile("^#(?:[0-9a-fA-F]{3}){1,2}$").matcher(hexColor).matches()) {
-        BotUtils.sendMessage(channel, author, "Color must be in hex format!", "Example: #FFFFFF");
+        BotUtils.sendMessage(channel, author, "Color must be in hex format!", "Example: #FFFFFF", Color.red);
         return false;
       }
 
@@ -122,7 +122,7 @@ public class NameColorCommand implements Command {
 
     member.addRole(role.getId()).block();
 
-    BotUtils.sendMessage(channel, author, "Color sucessfully changed!", "");
+    BotUtils.sendMessage(channel, author, "Color sucessfully changed!", "", Color.green);
   }
 
   /**


### PR DESCRIPTION
Green for successful, red for unsuccessful. I left help messages unchanged, as there was no include for .awt.Color, so it appears that help messages are intended to be the default color.